### PR TITLE
in Xcode 8.2, macOS framework needs SWIFT_VERSION set on targets

### DIFF
--- a/CwlSignal.xcodeproj/project.pbxproj
+++ b/CwlSignal.xcodeproj/project.pbxproj
@@ -593,6 +593,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cocoawithlove.CwlSignal-macOS";
 				PRODUCT_NAME = CwlSignal;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -614,6 +615,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cocoawithlove.CwlSignal-macOS";
 				PRODUCT_NAME = CwlSignal;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
A small project update. Xcode 8.2 seems to want SWIFT_VERSION set on the targets directly, at least for the macOS target.