### PR TITLE
LICENSE: add title

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+ISC License
+
 Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved.
 
 Permission to use, copy, modify, and/or distribute this software for any


### PR DESCRIPTION
The title is not legally mandated, but it's convenient for human consumption; it also works as additional metadata, and is part of the recommended license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license).

*This PR is part of a project to improve the consistency and visibility of the ISC license. See https://github.com/github/choosealicense.com/issues/377 for more details.*