### PR TITLE
Pass through the invocation context

### DIFF
--- a/Sources/CwlSignal/CwlSignalExtensions.swift
+++ b/Sources/CwlSignal/CwlSignalExtensions.swift
@@ -252,7 +252,7 @@ extension SignalInterface {
 	///   - context: the execution context where the `processor` will be invoked
 	///   - handler: will be invoked with each value received and if returns `false`, the endpoint will be cancelled and released
 	public func subscribeUntilEnd(context: Exec = .direct, handler: @escaping (Result<OutputValue>) -> Void) {
-		return signal.subscribeWhile(handler: { (result: Result<OutputValue>) -> Bool in
+        return signal.subscribeWhile(context: context, handler: { (result: Result<OutputValue>) -> Bool in
 			handler(result)
 			return true
 		})


### PR DESCRIPTION
Fixing a probable typo. Caught thanks to main thread sanitiser.