### PR TITLE
Fixed linker error when building Release configuration with Xcode 12

### DIFF
--- a/Dependencies/CwlUtils/Sources/CwlUtils/CwlDeque.swift
+++ b/Dependencies/CwlUtils/Sources/CwlUtils/CwlDeque.swift
@@ -398,7 +398,7 @@ public struct Deque<T>: RandomAccessCollection, MutableCollection, RangeReplacea
 }
 
 // Internal state for the Deque
-private struct DequeHeader {
+public struct DequeHeader {
 	var offset: Int
 	var count: Int
 	var capacity: Int
@@ -455,7 +455,7 @@ private struct HeapObject {
 // storage and then using raw pointer offsets into self to access contents
 // (avoiding the ManagedBufferPointer accessors which are a performance problem
 // in Swift 3).
-private final class DequeBuffer<T>: ManagedBuffer<DequeHeader, T> {
+public final class DequeBuffer<T>: ManagedBuffer<DequeHeader, T> {
 	#if true
 		private static var headerOffset: Int {
 			return Int(roundUp(UInt(MemoryLayout<HeapObject>.size), toAlignment: MemoryLayout<DequeHeader>.alignment))


### PR DESCRIPTION
`Undefined symbols for architecture arm64:
  "type metadata accessor for CwlUtils.(DequeBuffer in _205C59B1D6FDABD6FAE37E9199C346A4)", referenced from:
      CwlSignal.Signal.send(result: Swift.Result<A, CwlSignal.SignalEnd>, predecessor: Swift.Unmanaged<Swift.AnyObject>?, activationCount: Swift.Int, activated: Swift.Bool) -> CwlSignal.SignalSendError? in CwlSignal.o
      CwlSignal.Signal.(specializedSyncPop in _ACD91BA4CE4CE61201EA964A7D8CD939)() -> () in CwlSignal.o
      CwlSignal.Signal.(resumeIfPossibleInternal in _ACD91BA4CE4CE61201EA964A7D8CD939)(dw: inout CwlUtils.DeferredWork) -> () in CwlSignal.o
      CwlSignal.Signal.(pop in _ACD91BA4CE4CE61201EA964A7D8CD939)() -> Swift.Result<A, CwlSignal.SignalEnd>? in CwlSignal.o`